### PR TITLE
Fixed path naming inconsistencies.

### DIFF
--- a/CoreObjectModel/MetadataHelper/MetadataHelper.csproj
+++ b/CoreObjectModel/MetadataHelper/MetadataHelper.csproj
@@ -110,11 +110,11 @@
     <CodeAnalysisRules />
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\..\common\include\Version.cs">
+    <Compile Include="..\..\Common\Include\Version.cs">
       <Link>Build\Version.cs</Link>
     </Compile>
-    <Compile Include="..\..\common\include\PortingHelpers.cs" />
-    <Compile Include="..\..\common\include\DietCollection.cs" />
+    <Compile Include="..\..\Common\Include\PortingHelpers.cs" />
+    <Compile Include="..\..\Common\Include\DietCollection.cs" />
     <Compile Include="AttributeHelper.cs" />
     <Compile Include="CommandLineOptions.cs" />
     <Compile Include="Core.cs" />

--- a/CoreObjectModel/MetadataModel/MetadataModel.csproj
+++ b/CoreObjectModel/MetadataModel/MetadataModel.csproj
@@ -106,10 +106,10 @@
     <CodeAnalysisRules />
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\..\common\include\Version.cs">
+    <Compile Include="..\..\Common\Include\Version.cs">
       <Link>Build\Version.cs</Link>
     </Compile>
-    <Compile Include="..\..\common\include\DietCollection.cs" />
+    <Compile Include="..\..\Common\Include\DietCollection.cs" />
     <Compile Include="NameScope.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Core.cs" />

--- a/CoreObjectModel/SourceModel/SourceModel.csproj
+++ b/CoreObjectModel/SourceModel/SourceModel.csproj
@@ -99,10 +99,10 @@
     <DocumentationFile>bin\Release\Microsoft.Cci.SourceModel.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\..\common\include\Version.cs">
+    <Compile Include="..\..\Common\Include\Version.cs">
       <Link>Build\Version.cs</Link>
     </Compile>
-    <Compile Include="..\..\common\include\DietCollection.cs" />
+    <Compile Include="..\..\Common\Include\DietCollection.cs" />
     <Compile Include="DummyObjects.cs" />
     <Compile Include="Implementations.cs" />
     <Compile Include="Interfaces.cs" />

--- a/PDBReaderAndWriter/PdbReader/PdbReader.csproj
+++ b/PDBReaderAndWriter/PdbReader/PdbReader.csproj
@@ -97,10 +97,10 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\..\common\include\Version.cs">
+    <Compile Include="..\..\Common\Include\Version.cs">
       <Link>Build\Version.cs</Link>
     </Compile>
-    <Compile Include="..\..\common\include\DietCollection.cs" />
+    <Compile Include="..\..\Common\Include\DietCollection.cs" />
     <Compile Include="BitAccess.cs" />
     <Compile Include="BitSet.cs" />
     <Compile Include="CvInfo.cs" />

--- a/PEReaderAndWriter/PEReader/PeReader.csproj
+++ b/PEReaderAndWriter/PEReader/PeReader.csproj
@@ -124,12 +124,12 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\..\common\include\Version.cs">
+    <Compile Include="..\..\Common\Include\Version.cs">
       <Link>Build\Version.cs</Link>
     </Compile>
-    <Compile Include="..\..\common\include\PortingHelpers.cs" />
-    <Compile Include="..\..\common\include\DietCollection.cs" />
-    <Compile Include="..\..\common\include\CciEventSource.cs" />
+    <Compile Include="..\..\Common\Include\PortingHelpers.cs" />
+    <Compile Include="..\..\Common\Include\DietCollection.cs" />
+    <Compile Include="..\..\Common\Include\CCIEventSource.cs" />
     <Compile Include="AliasForTypeExtensions.cs" />
     <Compile Include="Attributes.cs" />
     <Compile Include="BinaryObjectModel.cs" />


### PR DESCRIPTION
Hi @michael-emmi 

In this pull request, a few paths are fixed. I'm only fixing those .csproj that are used by analysis-net as dependencies.

The error only raises in linux. In the past, we had the ability to set an environment variable to change mono behavior. However, in newer versions of mono that option is [gone](https://github.com/mono/mono/issues/15845). 